### PR TITLE
Fix/api

### DIFF
--- a/src/parking-sensors/parking-sensors-sensors.controller.spec.ts
+++ b/src/parking-sensors/parking-sensors-sensors.controller.spec.ts
@@ -59,6 +59,8 @@ describe('ParkingSensorsController', () => {
 
   describe('getAllParkingSensorsBySensorId', () => {
     it('should return a the parking sensor if the sensor was found', async () => {
+        jest.spyOn(sensorsService, 'getSensorById')
+            .mockImplementation(() => Promise.resolve(sensor));
         jest.spyOn(parkingSensorsService, 'getAllParkingSensorsBySensorId')
             .mockImplementation(() => Promise.resolve(parkingSensors));
 
@@ -69,7 +71,7 @@ describe('ParkingSensorsController', () => {
     });
 
     it('should throw an HtppException if the sensor wasn\'t found', async () => {
-        jest.spyOn(parkingSensorsService, 'getAllParkingSensorsBySensorId')
+        jest.spyOn(sensorsService, 'getSensorById')
             .mockImplementation(() => Promise.resolve(null));
 
         const response = 

--- a/src/parking-sensors/parking-sensors-sensors.controller.ts
+++ b/src/parking-sensors/parking-sensors-sensors.controller.ts
@@ -12,12 +12,15 @@ export class ParkingSensorsSensorsController{
 
     @Get()
     async getAllParkingSensorsBySensorId(@Param('id') id: string){
+        const sensor = 
+            await this.sensorsService.getSensorById(id);
+
+        if(isEmpty(sensor))
+            throw new HttpException('', HttpStatus.NOT_FOUND);
+
         const parkingSensors = 
             await this.parkingSensorsService.getAllParkingSensorsBySensorId(id);
         
-        if(!isEmpty(parkingSensors))
-            return parkingSensors;
-        else
-            throw new HttpException('', HttpStatus.NOT_FOUND);
+        return parkingSensors;
     }
 }

--- a/src/parking-spots/parking-spots-parking-areas.controller.spec.ts
+++ b/src/parking-spots/parking-spots-parking-areas.controller.spec.ts
@@ -64,8 +64,10 @@ describe('ParkingSpotsParkingAreasController', () => {
 
   describe('getAllParkingSpotsByParkingAreaId', () => {
     it('should return the parking spots if the parking area was found', async () => {
+      jest.spyOn(parkingAreasService, 'getParkingAreaById')
+        .mockImplementation(() => Promise.resolve(parkingArea));
       jest.spyOn(parkingSpotsService, 'getAllParkingSpotsByParkingAreaId')
-        .mockImplementation(() => parkingSpots);
+        .mockImplementation(() => Promise.resolve(parkingSpots));
 
       const response = 
         parkingSpotsParkingAreasController.getAllParkingSpotsByParkingAreaId('1');
@@ -74,7 +76,7 @@ describe('ParkingSpotsParkingAreasController', () => {
     })
 
     it('should throw an HttpException if the parking area was not found', async () => {
-      jest.spyOn(parkingSpotsService, 'getAllParkingSpotsByParkingAreaId')
+      jest.spyOn(parkingAreasService, 'getParkingAreaById')
         .mockImplementation(() => Promise.resolve(null));
 
       const response = 

--- a/src/parking-spots/parking-spots-parking-areas.controller.ts
+++ b/src/parking-spots/parking-spots-parking-areas.controller.ts
@@ -1,5 +1,4 @@
 import { Body, Controller, Get, HttpException, HttpStatus, Param, Post } from "@nestjs/common";
-import { ParkingArea } from "src/parking-areas/entities/parking-area.entity";
 import { ParkingAreasService } from "src/parking-areas/parking-areas.service";
 import { ParkingSpotsService } from "./parking-spots.service";
 import { isEmpty } from "underscore"
@@ -17,14 +16,16 @@ export class ParkingSpotsParkingAreasController{
 
     @Get()
     async getAllParkingSpotsByParkingAreaId(@Param('id') id: string){
-        
+        const parkingArea =
+            await this.parkingAreasService.getParkingAreaById(id);
+
+        if(isEmpty(parkingArea))
+            throw new HttpException('', HttpStatus.NOT_FOUND);
+
         const parkingSpots = 
             await this.parkingSpotsService.getAllParkingSpotsByParkingAreaId(id);
 
-        if(!isEmpty(parkingSpots))
-            return parkingSpots;
-        else
-            throw new HttpException('', HttpStatus.NOT_FOUND)
+        return parkingSpots;
     }
 
     @Post()

--- a/src/parking-spots/parking-spots.module.ts
+++ b/src/parking-spots/parking-spots.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ParkingSpot } from './entities/parking-spot.entity';
 import { ParkingSpotsRepository } from './parking-spots.repository';
@@ -13,7 +13,7 @@ import { SensorsModule } from 'src/sensors/sensors.module';
     imports: [ 
         TypeOrmModule.forFeature([ ParkingSpot ]),
         ParkingAreasModule,
-        SensorsModule,
+        forwardRef(() => SensorsModule),
     ],
     controllers: [
         ParkingSpotsController, 
@@ -24,6 +24,8 @@ import { SensorsModule } from 'src/sensors/sensors.module';
         ParkingSpotsService,
         ParkingSpotsRepository,
     ],
-    exports: [],
+    exports: [
+        ParkingSpotsService,
+    ],
 })
 export class ParkingSpotsModule {}

--- a/src/sensors-scraping/sensors-scraping.service.ts
+++ b/src/sensors-scraping/sensors-scraping.service.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios';
-import { HttpException, Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { SensorScrapingDto } from './dto/sensor-scraping.dto';
 import { firstValueFrom, from } from 'rxjs';
@@ -30,7 +30,7 @@ export class SensorsScrapingService{
             SensorScrapingDtoToParkingSensorAutomapper,
         ){}
 
-    @Cron('*/2 * * * *')
+    //@Cron('*/2 * * * *')
     async scrapeAndPersistSensors() {
         this.logger.log('Started scraping sensors...');
 

--- a/src/sensors/sensors-parking-spots.controller.spec.ts
+++ b/src/sensors/sensors-parking-spots.controller.spec.ts
@@ -1,12 +1,15 @@
 import { createMock } from '@golevelup/ts-jest';
 import { HttpException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ParkingSpotsService } from 'src/parking-spots/parking-spots.service';
 import { SensorsParkingSpotsController } from './sensors-parking-spots.controller';
 import { SensorsService } from './sensors.service';
 
 describe('SensorsParkingSpotsController', () => {
   let sensorsParkingSpotsController: SensorsParkingSpotsController;
   let sensorsService: SensorsService;
+  let parkingSpotsService: ParkingSpotsService;
+  let parkingSpot;
   let sensors;
 
   beforeEach(async () => {
@@ -16,15 +19,34 @@ describe('SensorsParkingSpotsController', () => {
         {
           provide: SensorsService,
           useValue: createMock<SensorsService>(),
-        }
+        },
+        {
+          provide: ParkingSpotsService,
+          useValue: createMock<ParkingSpotsService>(),
+        },
       ]
     }).compile();
 
     sensorsParkingSpotsController = 
-        module.get<SensorsParkingSpotsController>(SensorsParkingSpotsController);
+      module.get<SensorsParkingSpotsController>(SensorsParkingSpotsController);
     sensorsService = 
-        module.get<SensorsService>(SensorsService);
+      module.get<SensorsService>(SensorsService);
+    parkingSpotsService = 
+      module.get<ParkingSpotsService>(ParkingSpotsService);
   });
+
+  parkingSpot = {
+    id: '1',
+    latitude: '31.855173',
+    longitude: '31.859173',
+    parkingArea: {
+      id: '1',
+      address: 'Via Forcellini',
+      latitude: '48.407958',
+      longitude: '48.411958'
+    },
+    sensors: sensors
+  }
 
   sensors = [
     {
@@ -49,6 +71,8 @@ describe('SensorsParkingSpotsController', () => {
 
   describe('getAllSensorsByParkingSpotId', () => {
     it('should return the sensors if parking spot was found', async () => {
+        jest.spyOn(parkingSpotsService, 'getParkingSpotById')
+          .mockImplementation(() => Promise.resolve(parkingSpot));
         jest.spyOn(sensorsService, 'getAllSensorsByParkingSpotId')
             .mockImplementation(() => Promise.resolve(sensors));
 
@@ -59,8 +83,8 @@ describe('SensorsParkingSpotsController', () => {
     });
 
     it('should thrown an HttpException if the parking sensor wasn\'t found', async () => {
-        jest.spyOn(sensorsService, 'getAllSensorsByParkingSpotId')
-            .mockImplementation(() => Promise.resolve(null));
+        jest.spyOn(parkingSpotsService, 'getParkingSpotById')
+          .mockImplementation(() => Promise.resolve(null));
 
         const response = 
             sensorsParkingSpotsController.getAllSensorsByParkingSpotId('1');

--- a/src/sensors/sensors-parking-spots.controller.ts
+++ b/src/sensors/sensors-parking-spots.controller.ts
@@ -14,7 +14,7 @@ export class SensorsParkingSpotsController{
     async getAllSensorsByParkingSpotId(@Param('id') id: string){
         const parkingSpot = 
             await this.parkingSpotsService.getParkingSpotById(id);
-        console.log(parkingSpot)
+        
         if(isEmpty(parkingSpot))
             throw new HttpException('', HttpStatus.NOT_FOUND);
 

--- a/src/sensors/sensors-parking-spots.controller.ts
+++ b/src/sensors/sensors-parking-spots.controller.ts
@@ -1,42 +1,26 @@
 import { Controller, Get, HttpException, HttpStatus, Param } from "@nestjs/common";
 import { SensorsService } from "./sensors.service";
 import { isEmpty } from "underscore";
+import { ParkingSpotsService } from "src/parking-spots/parking-spots.service";
 
 @Controller('parking-spots/:id/sensors')
 export class SensorsParkingSpotsController{
     constructor(
-        private readonly sensorsService: SensorsService
+        private readonly sensorsService: SensorsService,
+        private readonly parkingSpotsService: ParkingSpotsService,
     ){}
 
     @Get()
     async getAllSensorsByParkingSpotId(@Param('id') id: string){
-        const sensorsTest = [
-            {
-                'id': '1',
-                'name': '156A2B71',
-                'battery': '3,7V',
-                'charge': '3',
-                'type': 'ParkingSensor',
-                'isActive': true,
-                'lastSurvey': new Date(),
-            },
-            {
-                'id': '2',
-                'name': '156A2C72',
-                'battery': '3,7V',
-                'charge': '3',
-                'type': 'ParkingSensor',
-                'isActive': true,
-                'lastSurvey': new Date(),
-            }
-        ];
-        
+        const parkingSpot = 
+            await this.parkingSpotsService.getParkingSpotById(id);
+        console.log(parkingSpot)
+        if(isEmpty(parkingSpot))
+            throw new HttpException('', HttpStatus.NOT_FOUND);
+
         const sensors = 
             await this.sensorsService.getAllSensorsByParkingSpotId(id);
 
-        if(!isEmpty(sensors))
-            return sensors;
-        else
-            throw new HttpException('', HttpStatus.NOT_FOUND);
+        return sensors;
     }
 }

--- a/src/sensors/sensors.module.ts
+++ b/src/sensors/sensors.module.ts
@@ -1,14 +1,16 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Sensor } from './entities/sensor.entity';
 import { SensorsRepository } from './sensors.repository';
 import { SensorsService } from './sensors.service';
 import { SensorsController } from './sensors.controller';
 import { SensorsParkingSpotsController } from './sensors-parking-spots.controller';
+import { ParkingSpotsModule } from 'src/parking-spots/parking-spots.module';
 
 @Module({
     imports: [ 
         TypeOrmModule.forFeature([ Sensor ]),
+        forwardRef(() => ParkingSpotsModule),
     ],
     providers: [
         SensorsService,


### PR DESCRIPTION
Fixed the problem in some api, that couldn't distinguish from the response if the status code 404 error was caused by the not found id passed or the id passed hadn't fields associated. Now the status code 404 is only caused by id passed not found, if the id passed is found but has not fields associated, it return an empty array with status code 200.